### PR TITLE
Update git config to use personal access token

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag reviewdog-golangci-lint:$(date +%s)
+      run: docker build . --file Dockerfile --tag jenakan-golangci-lint:$(date +%s)

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,7 @@
 name: reviewdog
 on: [pull_request]
+env:
+  ORG_TOKEN: ${{ secrets.github_token }}
 jobs:
   # NOTE: golangci-lint doesn't report multiple errors on the same line from
   # different linters and just report one of the errors?
@@ -12,7 +14,7 @@ jobs:
         uses: actions/checkout@v1
       - name: golangci-lint
         # uses: ./ # Build with Dockerfile
-        uses: docker://reviewdog/action-golangci-lint:v1 # Pre-built image
+        uses: docker://jenakan/action-golangci-lint:v1 # Pre-built image
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.github/.golangci.yml ./testdata"
@@ -25,7 +27,7 @@ jobs:
         uses: actions/checkout@v1
       - name: golangci-lint w/ Dockerfile
         uses: ./ # Build with Dockerfile
-        # uses: docker://reviewdog/action-golangci-lint:v1 # Pre-built image
+        # uses: docker://jenakan/action-golangci-lint:v1 # Pre-built image
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "./testdata"
@@ -67,7 +69,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: golangci-lint (All-In-One config)
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--enable-all --exclude-use-default=false ./testdata"
@@ -79,7 +81,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: govet
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E govet ./testdata"
@@ -92,7 +94,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: staticcheck
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E staticcheck ./testdata"
@@ -105,7 +107,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: golint
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint ./testdata"
@@ -119,7 +121,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: errcheck
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck ./testdata"
@@ -133,7 +135,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: misspell
-        uses: docker://reviewdog/action-golangci-lint:v1
+        uses: docker://jenakan/action-golangci-lint:v1
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E misspell ./testdata"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,8 @@ cd "$GITHUB_WORKSPACE" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+git config --global url."https://${ORG_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
 # shellcheck disable=SC2086
 golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
   | reviewdog -f=golangci-lint -name="${INPUT_TOOL_NAME}" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
This action is intended to be run in private repo with private dependencies. For this action to execute correctly, need to update git config to use personal access token to pull down private dependencies.

See https://github.com/golangci/golangci-lint/issues/897\#issuecomment-573783854